### PR TITLE
Automatically open the result if there is only one match #11

### DIFF
--- a/app/src/main/java/me/robbyblue/mylauncher/search/SearchActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/search/SearchActivity.java
@@ -130,6 +130,13 @@ public class SearchActivity extends Activity {
         recycler.scrollToPosition(0);
     }
 
+    
+    // Automatically open the result if there is only one match
+    if (searchResults != null && searchResults.size() == 1) {
+        searchResults.get(0).open(this);
+        finish();
+    }
+
     public String getSearchQuery() {
         EditText searchBar = findViewById(R.id.search_bar);
         return searchBar.getText().toString();


### PR DESCRIPTION
Hot fix for Issue #11
I don't know if this works, I just clicked on the Copilot button out of curiosity… If that helps you, use it, but I don't know if hard coding it is the right way to go, because a switch in the general settings to disable/enable that doesn't exist yet would still need to be considered.