### PR TITLE
feat: Normalisation of all accents

### DIFF
--- a/app/src/main/java/me/robbyblue/mylauncher/search/NamedItem.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/search/NamedItem.java
@@ -1,5 +1,7 @@
 package me.robbyblue.mylauncher.search;
 
+import java.text.Normalizer;
+
 import me.robbyblue.mylauncher.files.FileNode;
 
 public class NamedItem {
@@ -20,8 +22,8 @@ public class NamedItem {
         return fileNode;
     }
 
-    public void normalizeUmlaute() {
-        this.name = name.replace("ä", "a").replace("ö", "o")
-                .replace("ü", "u");
+    public void normalizeAccents() {
+        this.name = Normalizer.normalize(name, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "");
     }
 }

--- a/app/src/main/java/me/robbyblue/mylauncher/search/SearchActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/search/SearchActivity.java
@@ -21,6 +21,7 @@ import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import java.text.Normalizer;
 import java.util.ArrayList;
 
 import me.robbyblue.mylauncher.AppsListCache;
@@ -52,11 +53,11 @@ public class SearchActivity extends Activity {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         boolean autoOpenOnlyResult = prefs.getBoolean("pref_search_auto_open_only", false);
         boolean showShortcuts = prefs.getBoolean("pref_search_show_shortcuts", true);
-        boolean normalizeUmlaute = prefs.getBoolean("pref_search_normalize_umlaute", true);
+        boolean normalizeAccents = prefs.getBoolean("pref_search_normalize_umlaute", true);
 
         int appTextColor = prefs.getInt("pref_app_text_color", Color.parseColor("#EEEEEE"));
 
-        searchableItems = indexSearchableItems(showShortcuts, normalizeUmlaute);
+        searchableItems = indexSearchableItems(showShortcuts, normalizeAccents);
 
         recycler = findViewById(R.id.app_recycler);
 
@@ -109,9 +110,9 @@ public class SearchActivity extends Activity {
                 if (query.contains(".")) {
                     searchResults = search.searchDots(query);
                 } else {
-                    if(normalizeUmlaute){
-                        query = query.replace("ä", "a").replace("ö", "o")
-                                .replace("ü", "u");
+                    if(normalizeAccents){
+                        query = Normalizer.normalize(query, Normalizer.Form.NFD)
+                                .replaceAll("\\p{M}", "");
                     }
 
                     searchResults = search.searchFiles(query, searchableItems);
@@ -165,7 +166,7 @@ public class SearchActivity extends Activity {
         return gestureDetector.onTouchEvent(event);
     }
 
-    private ArrayList<NamedItem> indexSearchableItems(boolean showShortcuts, boolean normalizeUmlaute) {
+    private ArrayList<NamedItem> indexSearchableItems(boolean showShortcuts, boolean normalizeAccents) {
         // add apps by their actual names
         ArrayList<NamedItem> items = new ArrayList<>();
 
@@ -212,9 +213,9 @@ public class SearchActivity extends Activity {
             }
         }
 
-        if(normalizeUmlaute) {
+        if(normalizeAccents) {
             for (NamedItem item : items) {
-                item.normalizeUmlaute();
+                item.normalizeAccents();
             }
         }
         return items;

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -86,9 +86,9 @@
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="pref_search_normalize_umlaute"
-            android:summaryOff="won't normalize umlaute"
-            android:summaryOn="will normalize umlaute"
-            android:title="normalize umlaute"
+            android:summaryOff="won't normalize accents"
+            android:summaryOn="will normalize accents"
+            android:title="normalize accents"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 

--- a/app/src/test/java/me/robbyblue/mylauncher/search/NamedItemTest.java
+++ b/app/src/test/java/me/robbyblue/mylauncher/search/NamedItemTest.java
@@ -1,0 +1,47 @@
+package me.robbyblue.mylauncher.search;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import me.robbyblue.mylauncher.files.FileNode;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class NamedItemTest {
+
+    @Parameterized.Parameter(0)
+    public String input;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "Paramètres", "parametres" },
+            { "Über", "uber" },
+            { "Español", "espanol" },
+            { "niño", "nino" },
+            { "Ça fait très beau", "ca fait tres beau" },
+            { "Settings", "settings" },
+            { "PARAMETRES", "parametres" },
+            { "RÉsumÉ", "resume" },
+            { "Crème brulée", "creme brulee" },
+            { "naïve", "naive" },
+            { "façade", "facade" },
+            { "Jörg", "jorg" },
+        });
+    }
+
+    @Test
+    public void normalizeAccents() {
+        FileNode mockFileNode = null;
+        NamedItem item = new NamedItem(input, mockFileNode);
+        item.normalizeAccents();
+        assertEquals(expected, item.getName());
+    }
+}


### PR DESCRIPTION
First of all, thank you for this launcher. I have been unsing it for a month now and am pretty content with all of it (except missing widget configuration on my). But let's get to the topic. I wanted to contribute more complete normalisation handling.

This PR improves app search to handle Unicode accents, not just German umlauts. Previously, searching only handled ä, ö, ü -> a, o, u. Now using Java's Normalizer with NFD decomposition and Unicode combining marks removal, searching "Parametres" on a french device will correctly match "Paramètres", which did not match before. This handles all Unicode accents across languages including French, Spanish, German, and more. I took the freedom to repurpose the preexisting umlaut normalisation to replace it bit the more general one. Let me know if this is okay, or if I should add this as a separate functionality.

The second commit 9e7020e renames the settings key for this to `pref_search_normalize_accents`. This change is optional as it would reset the users' selection on this setting to  default (true). So you can decide to 1. Rename key for cleanliness - but lose saved setting, or 2. Keep old key; works inconsistent naming.

I have added some tests with various examples using JUnit 4's `@RunWith(Parameterized.class)` to avoid repetition. This was also tested in an emulated device.

Let me know if you prefer anything to be different, I could integrate. Looking forward for your response, mauz