### PR TITLE
feat: Add widget configuration

### DIFF
--- a/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
@@ -194,15 +194,15 @@ public class WidgetSetupActivity extends AppCompatActivity {
                 double size = number / 100d;
 
                 if (creatingRow) {
-                    WidgetList list = new WidgetList(size);
+                    WidgetList list = new WidgetList(number / 100d);
                     WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
                     widgetList.addChild(list);
                     fs.storeFilesStructure();
                     showLayout();
                 } else if (needsConfig) {
-                    launchConfigForWidget(widgetId, size, isWidget);
+                    launchConfigForWidget(widgetId, number, isWidget);
                 } else {
-                    addWidgetDirectly(widgetId, size, isWidget);
+                    addWidgetDirectly(widgetId, number, isWidget);
                 }
             } catch (NumberFormatException e) {
                 Toast.makeText(this, "invalid number", Toast.LENGTH_LONG).show();
@@ -220,7 +220,7 @@ public class WidgetSetupActivity extends AppCompatActivity {
     }
 
     private void addWidgetDirectly(int appWidgetId, double size, boolean inRow) {
-        WidgetElement element = new WidgetElement(appWidgetId, (int) (size * 100));
+        WidgetElement element = new WidgetElement(appWidgetId, size / 100d);
 
         FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
         WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
@@ -241,7 +241,7 @@ public class WidgetSetupActivity extends AppCompatActivity {
         android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
 
         if (widgetInfo != null && widgetInfo.configure != null) {
-            pendingElement = new WidgetElement(appWidgetId, (int) (size * 100));
+            pendingElement = new WidgetElement(appWidgetId, size / 100d);
             this.isInRow = inRow;
 
             ComponentName configureComponent = widgetInfo.configure;

--- a/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
@@ -4,8 +4,10 @@ import android.appwidget.AppWidgetHost;
 import android.appwidget.AppWidgetManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ComponentName;
 import android.os.Bundle;
 import android.text.InputType;
+import android.net.Uri;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -28,29 +30,60 @@ public class WidgetSetupActivity extends AppCompatActivity {
 
     boolean isInRow = false;
     String folder;
+    int pendingWidgetId = -1;
+    boolean pendingNeedsConfig = false;
+    WidgetElement pendingElement = null;
+
+    ActivityResultLauncher<Intent> configureIntentLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+        if (pendingElement == null) return;
+
+        if (result.getResultCode() != RESULT_OK) {
+            AppWidgetHost host = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
+            host.deleteAppWidgetId(pendingElement.getAppWidgetId());
+            pendingElement = null;
+            return;
+        }
+
+        addConfiguredWidget(pendingElement, isInRow);
+        pendingElement = null;
+    });
 
     ActivityResultLauncher<Intent> pickWidgetLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
         if (result.getResultCode() != RESULT_OK) return;
 
-        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
-
         int appWidgetId = result.getData().getExtras().getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, -1);
 
-        WidgetElement element = new WidgetElement(appWidgetId, 1);
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
+        android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
 
-        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+        pendingWidgetId = appWidgetId;
+        pendingNeedsConfig = (widgetInfo != null && widgetInfo.configure != null);
+
+        if (pendingNeedsConfig) {
+            pendingElement = new WidgetElement(appWidgetId, 100);
+        }
 
         if (isInRow) {
+            showSizeDialog(true, pendingWidgetId, pendingNeedsConfig);
+        } else {
+            showSizeDialog(false, pendingWidgetId, pendingNeedsConfig);
+        }
+    });
+
+    private void addConfiguredWidget(WidgetElement element, boolean inRow) {
+        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+
+        if (inRow) {
             WidgetLayout lastElement = widgetList.getChildren().get(widgetList.getChildren().size() - 1);
             ((WidgetList) lastElement).addChild(element);
-
-            showSizeDialog(element, this);
         } else {
             widgetList.addChild(element);
         }
 
         fs.storeFilesStructure();
-    });
+        showLayout();
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -84,7 +117,7 @@ public class WidgetSetupActivity extends AppCompatActivity {
             pickWidget(false);
         });
         findViewById(R.id.add_row).setOnClickListener((l) -> {
-            showSizeDialog(null, this);
+            showSizeDialog(false, -1, false);
         });
         findViewById(R.id.add_widget_to_row).setOnClickListener((l) -> {
             if (widgetList.getChildren().size() == 0) {
@@ -134,17 +167,17 @@ public class WidgetSetupActivity extends AppCompatActivity {
         this.isInRow = isInRow;
     }
 
-    public void showSizeDialog(WidgetLayout widget, Context ctx) {
-        boolean isWidget = widget != null;
+    private void showSizeDialog(boolean isWidget, int widgetId, boolean needsConfig) {
+        boolean creatingRow = !isWidget && widgetId == -1;
 
-        EditText input = new EditText(ctx);
+        EditText input = new EditText(this);
         input.setInputType(InputType.TYPE_CLASS_NUMBER);
 
         int maxNumber = isWidget ? 100 : 300;
 
         LinearLayout titleLayout = getTitleLayout(isWidget, maxNumber);
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(ctx);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle("enter size (0-" + maxNumber + ")");
         builder.setView(input);
         builder.setCustomTitle(titleLayout);
@@ -159,22 +192,65 @@ public class WidgetSetupActivity extends AppCompatActivity {
                     return;
                 }
                 double size = number / 100d;
-                if (isWidget) {
-                    widget.setSize(size);
-                } else {
+
+                if (creatingRow) {
                     WidgetList list = new WidgetList(size);
                     WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
                     widgetList.addChild(list);
+                    fs.storeFilesStructure();
+                    showLayout();
+                } else if (needsConfig) {
+                    launchConfigForWidget(widgetId, size, isWidget);
+                } else {
+                    addWidgetDirectly(widgetId, size, isWidget);
                 }
-                fs.storeFilesStructure();
-                showLayout();
             } catch (NumberFormatException e) {
                 Toast.makeText(this, "invalid number", Toast.LENGTH_LONG).show();
             }
         });
 
-        builder.setNegativeButton("Cancel", null);
+        builder.setNegativeButton("Cancel", (dialog, which) -> {
+            if (needsConfig && widgetId != -1) {
+                AppWidgetHost host = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
+                host.deleteAppWidgetId(widgetId);
+                pendingElement = null;
+            }
+        });
         builder.show();
+    }
+
+    private void addWidgetDirectly(int appWidgetId, double size, boolean inRow) {
+        WidgetElement element = new WidgetElement(appWidgetId, (int) (size * 100));
+
+        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+
+        if (inRow) {
+            WidgetLayout lastElement = widgetList.getChildren().get(widgetList.getChildren().size() - 1);
+            ((WidgetList) lastElement).addChild(element);
+        } else {
+            widgetList.addChild(element);
+        }
+
+        fs.storeFilesStructure();
+        showLayout();
+    }
+
+    private void launchConfigForWidget(int appWidgetId, double size, boolean inRow) {
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
+        android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
+
+        if (widgetInfo != null && widgetInfo.configure != null) {
+            pendingElement = new WidgetElement(appWidgetId, (int) (size * 100));
+            this.isInRow = inRow;
+
+            ComponentName configureComponent = widgetInfo.configure;
+            Intent configureIntent = new Intent().setComponent(configureComponent);
+            configureIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+            configureIntent.putExtra("folder", folder);
+            configureIntent.setData(Uri.parse("widget:" + appWidgetId));
+            configureIntentLauncher.launch(configureIntent);
+        }
     }
 
     @NonNull

--- a/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetElement.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetElement.java
@@ -4,7 +4,7 @@ public class WidgetElement extends WidgetLayout {
 
     int appWidgetId;
 
-    public WidgetElement(int appWidgetId, int size){
+    public WidgetElement(int appWidgetId, double size){
         super();
         this.appWidgetId = appWidgetId;
         this.size = size;

--- a/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
@@ -60,7 +60,12 @@ public class WidgetSystem {
             minWidth = minHeight = 1;
         }
 
-        int height = (int) (screenWidth * minHeight / minWidth);
+        // For top-level widgets, use stored size with division
+        double heightValue = minHeight / (double) minWidth;
+        if (widget.getSize() > 0) {
+            heightValue = widget.getSize() / 100.0;
+        }
+        int height = (int) (screenWidth * heightValue);
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(screenWidth, height);
         childLayout.setLayoutParams(layoutParams);
         childLayout.setGravity(Gravity.CENTER);
@@ -93,7 +98,11 @@ public class WidgetSystem {
         Context ctx = container.getContext();
         LinearLayout childLayout = new LinearLayout(ctx);
 
-        int width = (int) (parentWidth * widget.getSize());
+        // For widgets in row: size stored as integer (30), need to divide by 100
+        // For rows: size stored as decimal (0.30), use as-is
+        double sizeValue = widget instanceof WidgetElement ? widget.getSize() / 100.0 : widget.getSize();
+        int width = (int) (parentWidth * sizeValue);
+        if (width < 20) width = 20;
 
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(width, parentHeight);
         childLayout.setLayoutParams(layoutParams);

--- a/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
@@ -60,10 +60,9 @@ public class WidgetSystem {
             minWidth = minHeight = 1;
         }
 
-        // For top-level widgets, use stored size with division
         double heightValue = minHeight / (double) minWidth;
         if (widget.getSize() > 0) {
-            heightValue = widget.getSize() / 100.0;
+            heightValue = widget.getSize();
         }
         int height = (int) (screenWidth * heightValue);
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(screenWidth, height);
@@ -98,10 +97,7 @@ public class WidgetSystem {
         Context ctx = container.getContext();
         LinearLayout childLayout = new LinearLayout(ctx);
 
-        // For widgets in row: size stored as integer (30), need to divide by 100
-        // For rows: size stored as decimal (0.30), use as-is
-        double sizeValue = widget instanceof WidgetElement ? widget.getSize() / 100.0 : widget.getSize();
-        int width = (int) (parentWidth * sizeValue);
+        int width = (int) (parentWidth * widget.getSize());
         if (width < 20) width = 20;
 
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(width, parentHeight);


### PR DESCRIPTION
Some Android widgets require configuration on first add (for example, to select which data to display). Others allow configuration giving more features. However, when adding a widget in SimpleFolderLauncher, this configuration was not being offered - the widget gets added without letting users configure it.

This PR adds that flow: when adding a widget, the launcher now checks if the widget has a configuration activity and launches it after the user sets the widget size. This way, widgets that need configuration work properly.
Size input now comes before configuration, not before, I found that more natural (set how big first, then its' config).
I tested this on an emulated device.

Let me know if you prefer any different choice.