### PR TITLE
feat: Improve widget navigation

### DIFF
--- a/app/src/main/java/me/robbyblue/mylauncher/MainActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/MainActivity.java
@@ -18,6 +18,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -367,12 +368,13 @@ public class MainActivity extends AppCompatActivity {
         Context ctx = getApplicationContext();
         AppWidgetHost appWidgetHost = new AppWidgetHost(ctx, APPWIDGET_HOST_ID);
 
-        HashMap<WidgetLayout, LinearLayout> layouts = WidgetSystem.createLayout(widgets, widgetContainer, false);
+        HashMap<WidgetLayout, FrameLayout> layouts = WidgetSystem.createLayout(widgets, widgetContainer, false, appWidgetHost);
+        appWidgetHost.startListening();
 
         for (WidgetLayout widgetLayout : layouts.keySet()) {
-            if (!(widgetLayout instanceof WidgetElement)) return;
+            if (!(widgetLayout instanceof WidgetElement)) continue;
 
-            LinearLayout layout = layouts.get(widgetLayout);
+            FrameLayout wrapper = layouts.get(widgetLayout);
             AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(ctx);
 
             int id = ((WidgetElement) widgetLayout).getAppWidgetId();
@@ -382,17 +384,15 @@ public class MainActivity extends AppCompatActivity {
                 continue;
             }
 
-            AppWidgetHostView hostView = appWidgetHost.createView(ctx, id, appWidgetManager.getAppWidgetInfo(id));
-
-            layout.addView(hostView);
-            appWidgetHost.startListening();
-
             int minWidth = appWidgetInfo.minWidth;
             int minHeight = appWidgetInfo.minHeight;
             int maxWidth = appWidgetInfo.minWidth;
             int maxHeight = appWidgetInfo.minHeight;
 
-            hostView.updateAppWidgetSize(new Bundle(), minWidth, minHeight, maxWidth, maxHeight);
+            AppWidgetHostView hostView = (AppWidgetHostView) wrapper.getChildAt(0);
+            if (hostView != null) {
+                hostView.updateAppWidgetSize(new Bundle(), minWidth, minHeight, maxWidth, maxHeight);
+            }
         }
     }
 

--- a/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
@@ -438,13 +438,31 @@ public class WidgetSetupActivity extends AppCompatActivity {
         builder.setView(input);
         builder.setCustomTitle(titleLayout);
 
-        builder.setPositiveButton("OK", (dialog, which) -> {
-            FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+        builder.setPositiveButton("OK", null);
+
+        builder.setNegativeButton("Cancel", (dialog, which) -> {
+            if (needsConfig && widgetId != -1) {
+                AppWidgetHost host = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
+                host.deleteAppWidgetId(widgetId);
+                pendingElement = null;
+            }
+        });
+
+        AlertDialog dialog = builder.show();
+
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+            FileDataStorage fs;
+            try {
+                fs = FileDataStorage.getInstanceAssumeExists();
+            } catch (Exception e) {
+                return;
+            }
 
             String numberText = input.getText().toString();
             try {
                 double number = Double.parseDouble(numberText);
                 if (number < 1 || number > maxNumber) {
+                    Toast.makeText(this, "Please enter a number between 1 and " + maxNumber, Toast.LENGTH_SHORT).show();
                     return;
                 }
                 double size = number / 100d;
@@ -460,19 +478,11 @@ public class WidgetSetupActivity extends AppCompatActivity {
                 } else {
                     addWidgetDirectly(widgetId, size, isWidget);
                 }
+                dialog.dismiss();
             } catch (NumberFormatException e) {
-                Toast.makeText(this, "invalid number", Toast.LENGTH_LONG).show();
+                Toast.makeText(this, "Invalid number", Toast.LENGTH_LONG).show();
             }
         });
-
-        builder.setNegativeButton("Cancel", (dialog, which) -> {
-            if (needsConfig && widgetId != -1) {
-                AppWidgetHost host = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
-                host.deleteAppWidgetId(widgetId);
-                pendingElement = null;
-            }
-        });
-        builder.show();
     }
 
     private void addWidgetDirectly(int appWidgetId, double size, boolean inRow) {

--- a/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.text.InputType;
 import android.net.Uri;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -33,6 +34,9 @@ public class WidgetSetupActivity extends AppCompatActivity {
     int pendingWidgetId = -1;
     boolean pendingNeedsConfig = false;
     WidgetElement pendingElement = null;
+    AppWidgetHost appWidgetHost;
+    HashMap<WidgetLayout, FrameLayout> currentLayouts;
+    WidgetList currentWidgetList;
 
     ActivityResultLauncher<Intent> configureIntentLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
         if (pendingElement == null) return;
@@ -52,16 +56,13 @@ public class WidgetSetupActivity extends AppCompatActivity {
         if (result.getResultCode() != RESULT_OK) return;
 
         int appWidgetId = result.getData().getExtras().getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, -1);
+        if (appWidgetId == -1) return;
 
         AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
         android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
 
         pendingWidgetId = appWidgetId;
         pendingNeedsConfig = (widgetInfo != null && widgetInfo.configure != null);
-
-        if (pendingNeedsConfig) {
-            pendingElement = new WidgetElement(appWidgetId, 100);
-        }
 
         if (isInRow) {
             showSizeDialog(true, pendingWidgetId, pendingNeedsConfig);
@@ -93,6 +94,9 @@ public class WidgetSetupActivity extends AppCompatActivity {
         Intent intent = getIntent();
         this.folder = intent.getStringExtra("folder");
 
+        appWidgetHost = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
+        appWidgetHost.startListening();
+
         FileDataStorage fs;
         try {
             fs = FileDataStorage.getInstance();
@@ -101,11 +105,6 @@ public class WidgetSetupActivity extends AppCompatActivity {
             return;
         }
         WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
-
-        widgetList.getChildren().removeIf((child) -> {
-            if (!(child instanceof WidgetList)) return false;
-            return ((WidgetList) child).getChildren().size() == 0;
-        });
 
         LinearLayout container = findViewById(R.id.widget_container);
 
@@ -133,29 +132,286 @@ public class WidgetSetupActivity extends AppCompatActivity {
 
     private void showLayout() {
         FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
-        AppWidgetHost appWidgetHost = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
 
         WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+        currentWidgetList = widgetList;
         LinearLayout container = findViewById(R.id.widget_container);
-        HashMap<WidgetLayout, LinearLayout> layouts = WidgetSystem.createLayout(widgetList, container, true);
+        currentLayouts = WidgetSystem.createLayout(widgetList, container, true, appWidgetHost);
 
-        for (WidgetLayout widgetLayout : layouts.keySet()) {
-            if (!(widgetLayout instanceof WidgetElement)) return;
+        for (WidgetLayout widgetLayout : currentLayouts.keySet()) {
+            FrameLayout layout = currentLayouts.get(widgetLayout);
 
-            LinearLayout layout = layouts.get(widgetLayout);
-            layout.setOnLongClickListener((l) -> {
-                widgetList.getChildren().removeIf((c) -> (c instanceof WidgetElement) && ((WidgetElement) c).getAppWidgetId() == ((WidgetElement) widgetLayout).getAppWidgetId());
-                for (WidgetLayout childWidget : widgetList.getChildren()) {
-                    if (!(childWidget instanceof WidgetList)) continue;
-                    ((WidgetList) childWidget).getChildren().removeIf((c) -> (c instanceof WidgetElement) && ((WidgetElement) c).getAppWidgetId() == ((WidgetElement) widgetLayout).getAppWidgetId());
-                }
-
-                appWidgetHost.deleteAppWidgetId(((WidgetElement) widgetLayout).getAppWidgetId());
-                fs.storeFilesStructure();
-                showLayout();
-                return true;
-            });
+            if (widgetLayout instanceof WidgetElement) {
+                final WidgetElement element = (WidgetElement) widgetLayout;
+                layout.setOnClickListener((l) -> {
+                    showWidgetMenu(element, layout);
+                });
+                layout.setOnLongClickListener((l) -> {
+                    showWidgetMenu(element, layout);
+                    return true;
+                });
+            } else if (widgetLayout instanceof WidgetList) {
+                final WidgetList row = (WidgetList) widgetLayout;
+                layout.setOnClickListener((l) -> {
+                    showRowMenu(row, layout);
+                });
+                layout.setOnLongClickListener((l) -> {
+                    showRowMenu(row, layout);
+                    return true;
+                });
+            }
         }
+    }
+
+    private void showWidgetMenu(WidgetElement element, FrameLayout layout) {
+        final boolean isInRow;
+        final WidgetList parentRow;
+        boolean foundInRow = false;
+        WidgetList foundRow = null;
+        for (WidgetLayout child : currentWidgetList.getChildren()) {
+            if (child instanceof WidgetList) {
+                WidgetList row = (WidgetList) child;
+                if (row.getChildren().contains(element)) {
+                    foundInRow = true;
+                    foundRow = row;
+                    break;
+                }
+            }
+        }
+        isInRow = foundInRow;
+        parentRow = foundRow;
+
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
+        android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(element.getAppWidgetId());
+        boolean hasConfig = widgetInfo != null && widgetInfo.configure != null;
+
+        String[] options;
+        if (isInRow) {
+            if (hasConfig) {
+                options = new String[]{"✕ Delete", "✎ Re-configure", "▲ Move row up", "▼ Move row down", "◀ Move left", "▶ Move right"};
+            } else {
+                options = new String[]{"✕ Delete", "▲ Move row up", "▼ Move row down", "◀ Move left", "▶ Move right"};
+            }
+        } else {
+            if (hasConfig) {
+                options = new String[]{"✕ Delete", "✎ Re-configure", "▲ Move up", "▼ Move down"};
+            } else {
+                options = new String[]{"✕ Delete", "▲ Move up", "▼ Move down"};
+            }
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle("Widget options");
+        builder.setItems(options, (dialog, which) -> {
+            int actionIndex = hasConfig ? which : (which >= 1 ? which + 1 : which);
+            if (isInRow) {
+                handleWidgetInRowAction(element, parentRow, actionIndex, hasConfig);
+            } else {
+                handleTopLevelWidgetAction(element, actionIndex, hasConfig);
+            }
+        });
+        builder.show();
+    }
+
+    private void handleWidgetInRowAction(WidgetElement element, WidgetList row, int which, boolean hasConfig) {
+        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+
+        if (hasConfig) {
+            switch (which) {
+                case 0:
+                    deleteWidget(element);
+                    break;
+                case 1:
+                    reconfigureWidget(element);
+                    break;
+                case 2:
+                    moveRowUp(row, widgetList);
+                    break;
+                case 3:
+                    moveRowDown(row, widgetList);
+                    break;
+                case 4:
+                    moveWidgetLeft(element, row);
+                    break;
+                case 5:
+                    moveWidgetRight(element, row);
+                    break;
+            }
+        } else {
+            switch (which) {
+                case 0:
+                    deleteWidget(element);
+                    break;
+                case 1:
+                    moveRowUp(row, widgetList);
+                    break;
+                case 2:
+                    moveRowDown(row, widgetList);
+                    break;
+                case 3:
+                    moveWidgetLeft(element, row);
+                    break;
+                case 4:
+                    moveWidgetRight(element, row);
+                    break;
+            }
+        }
+    }
+
+    private void handleTopLevelWidgetAction(WidgetElement element, int which, boolean hasConfig) {
+        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+
+        if (hasConfig) {
+            switch (which) {
+                case 0:
+                    deleteWidget(element);
+                    break;
+                case 1:
+                    reconfigureWidget(element);
+                    break;
+                case 2:
+                    moveWidgetUp(element, widgetList);
+                    break;
+                case 3:
+                    moveWidgetDown(element, widgetList);
+                    break;
+            }
+        } else {
+            switch (which) {
+                case 0:
+                    deleteWidget(element);
+                    break;
+                case 1:
+                    moveWidgetUp(element, widgetList);
+                    break;
+                case 2:
+                    moveWidgetDown(element, widgetList);
+                    break;
+            }
+        }
+    }
+
+    private void deleteWidget(WidgetElement element) {
+        currentWidgetList.getChildren().removeIf((c) -> (c instanceof WidgetElement) && ((WidgetElement) c).getAppWidgetId() == element.getAppWidgetId());
+        for (WidgetLayout childWidget : currentWidgetList.getChildren()) {
+            if (!(childWidget instanceof WidgetList)) continue;
+            ((WidgetList) childWidget).getChildren().removeIf((c) -> (c instanceof WidgetElement) && ((WidgetElement) c).getAppWidgetId() == element.getAppWidgetId());
+        }
+
+        appWidgetHost.deleteAppWidgetId(element.getAppWidgetId());
+        FileDataStorage.getInstanceAssumeExists().storeFilesStructure();
+        showLayout();
+    }
+
+    private void reconfigureWidget(WidgetElement element) {
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
+        android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(element.getAppWidgetId());
+
+        if (widgetInfo != null && widgetInfo.configure != null) {
+            pendingElement = element;
+            isInRow = false;
+            for (WidgetLayout child : currentWidgetList.getChildren()) {
+                if (child instanceof WidgetList && ((WidgetList) child).getChildren().contains(element)) {
+                    isInRow = true;
+                    break;
+                }
+            }
+
+            ComponentName configureComponent = widgetInfo.configure;
+            Intent configureIntent = new Intent().setComponent(configureComponent);
+            configureIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, element.getAppWidgetId());
+            configureIntent.putExtra("folder", folder);
+            configureIntent.setData(Uri.parse("widget:" + element.getAppWidgetId()));
+            configureIntentLauncher.launch(configureIntent);
+        }
+    }
+
+    private void moveRowUp(WidgetList row, WidgetList widgetList) {
+        int index = widgetList.getChildren().indexOf(row);
+        if (index > 0) {
+            widgetList.getChildren().remove(index);
+            widgetList.getChildren().add(index - 1, row);
+            FileDataStorage.getInstanceAssumeExists().storeFilesStructure();
+            showLayout();
+        }
+    }
+
+    private void moveRowDown(WidgetList row, WidgetList widgetList) {
+        int index = widgetList.getChildren().indexOf(row);
+        if (index >= 0 && index < widgetList.getChildren().size() - 1) {
+            widgetList.getChildren().remove(index);
+            widgetList.getChildren().add(index + 1, row);
+            FileDataStorage.getInstanceAssumeExists().storeFilesStructure();
+            showLayout();
+        }
+    }
+
+    private void moveWidgetLeft(WidgetElement element, WidgetList row) {
+        int index = row.getChildren().indexOf(element);
+        if (index > 0) {
+            row.getChildren().remove(index);
+            row.getChildren().add(index - 1, element);
+            FileDataStorage.getInstanceAssumeExists().storeFilesStructure();
+            showLayout();
+        }
+    }
+
+    private void moveWidgetRight(WidgetElement element, WidgetList row) {
+        int index = row.getChildren().indexOf(element);
+        if (index >= 0 && index < row.getChildren().size() - 1) {
+            row.getChildren().remove(index);
+            row.getChildren().add(index + 1, element);
+            FileDataStorage.getInstanceAssumeExists().storeFilesStructure();
+            showLayout();
+        }
+    }
+
+    private void moveWidgetUp(WidgetElement element, WidgetList widgetList) {
+        int index = widgetList.getChildren().indexOf(element);
+        if (index > 0) {
+            widgetList.getChildren().remove(index);
+            widgetList.getChildren().add(index - 1, element);
+            FileDataStorage.getInstanceAssumeExists().storeFilesStructure();
+            showLayout();
+        }
+    }
+
+    private void moveWidgetDown(WidgetElement element, WidgetList widgetList) {
+        int index = widgetList.getChildren().indexOf(element);
+        if (index >= 0 && index < widgetList.getChildren().size() - 1) {
+            widgetList.getChildren().remove(index);
+            widgetList.getChildren().add(index + 1, element);
+            FileDataStorage.getInstanceAssumeExists().storeFilesStructure();
+            showLayout();
+        }
+    }
+
+    private void showRowMenu(WidgetList row, FrameLayout layout) {
+        String[] options = {"✕ Delete", "▲ Move up", "▼ Move down"};
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle("Row options");
+        builder.setItems(options, (dialog, which) -> {
+            FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+            WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+
+            switch (which) {
+                case 0:
+                    widgetList.getChildren().remove(row);
+                    fs.storeFilesStructure();
+                    showLayout();
+                    break;
+                case 1:
+                    moveRowUp(row, widgetList);
+                    break;
+                case 2:
+                    moveRowDown(row, widgetList);
+                    break;
+            }
+        });
+        builder.show();
     }
 
     private void pickWidget(boolean isInRow) {
@@ -194,15 +450,15 @@ public class WidgetSetupActivity extends AppCompatActivity {
                 double size = number / 100d;
 
                 if (creatingRow) {
-                    WidgetList list = new WidgetList(size);
+                    WidgetList list = new WidgetList(number);
                     WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
                     widgetList.addChild(list);
                     fs.storeFilesStructure();
                     showLayout();
                 } else if (needsConfig) {
-                    launchConfigForWidget(widgetId, size, isWidget);
+                    launchConfigForWidget(widgetId, (int) number, isWidget);
                 } else {
-                    addWidgetDirectly(widgetId, size, isWidget);
+                    addWidgetDirectly(widgetId, (int) number, isWidget);
                 }
             } catch (NumberFormatException e) {
                 Toast.makeText(this, "invalid number", Toast.LENGTH_LONG).show();
@@ -219,8 +475,8 @@ public class WidgetSetupActivity extends AppCompatActivity {
         builder.show();
     }
 
-    private void addWidgetDirectly(int appWidgetId, double size, boolean inRow) {
-        WidgetElement element = new WidgetElement(appWidgetId, (int) (size * 100));
+    private void addWidgetDirectly(int appWidgetId, int sizePercent, boolean inRow) {
+        WidgetElement element = new WidgetElement(appWidgetId, sizePercent);
 
         FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
         WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
@@ -236,12 +492,12 @@ public class WidgetSetupActivity extends AppCompatActivity {
         showLayout();
     }
 
-    private void launchConfigForWidget(int appWidgetId, double size, boolean inRow) {
+    private void launchConfigForWidget(int appWidgetId, int sizePercent, boolean inRow) {
         AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
         android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
 
         if (widgetInfo != null && widgetInfo.configure != null) {
-            pendingElement = new WidgetElement(appWidgetId, (int) (size * 100));
+            pendingElement = new WidgetElement(appWidgetId, sizePercent);
             this.isInRow = inRow;
 
             ComponentName configureComponent = widgetInfo.configure;

--- a/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
@@ -4,8 +4,10 @@ import android.appwidget.AppWidgetHost;
 import android.appwidget.AppWidgetManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ComponentName;
 import android.os.Bundle;
 import android.text.InputType;
+import android.net.Uri;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -28,29 +30,60 @@ public class WidgetSetupActivity extends AppCompatActivity {
 
     boolean isInRow = false;
     String folder;
+    int pendingWidgetId = -1;
+    boolean pendingNeedsConfig = false;
+    WidgetElement pendingElement = null;
+
+    ActivityResultLauncher<Intent> configureIntentLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+        if (pendingElement == null) return;
+
+        if (result.getResultCode() != RESULT_OK) {
+            AppWidgetHost host = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
+            host.deleteAppWidgetId(pendingElement.getAppWidgetId());
+            pendingElement = null;
+            return;
+        }
+
+        addConfiguredWidget(pendingElement, isInRow);
+        pendingElement = null;
+    });
 
     ActivityResultLauncher<Intent> pickWidgetLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
         if (result.getResultCode() != RESULT_OK) return;
 
-        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
-
         int appWidgetId = result.getData().getExtras().getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, -1);
 
-        WidgetElement element = new WidgetElement(appWidgetId, 1);
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
+        android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
 
-        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+        pendingWidgetId = appWidgetId;
+        pendingNeedsConfig = (widgetInfo != null && widgetInfo.configure != null);
+
+        if (pendingNeedsConfig) {
+            pendingElement = new WidgetElement(appWidgetId, 100);
+        }
 
         if (isInRow) {
+            showSizeDialog(true, pendingWidgetId, pendingNeedsConfig);
+        } else {
+            showSizeDialog(false, pendingWidgetId, pendingNeedsConfig);
+        }
+    });
+
+    private void addConfiguredWidget(WidgetElement element, boolean inRow) {
+        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+
+        if (inRow) {
             WidgetLayout lastElement = widgetList.getChildren().get(widgetList.getChildren().size() - 1);
             ((WidgetList) lastElement).addChild(element);
-
-            showSizeDialog(element, this);
         } else {
             widgetList.addChild(element);
         }
 
         fs.storeFilesStructure();
-    });
+        showLayout();
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -84,7 +117,7 @@ public class WidgetSetupActivity extends AppCompatActivity {
             pickWidget(false);
         });
         findViewById(R.id.add_row).setOnClickListener((l) -> {
-            showSizeDialog(null, this);
+            showSizeDialog(false, -1, false);
         });
         findViewById(R.id.add_widget_to_row).setOnClickListener((l) -> {
             if (widgetList.getChildren().size() == 0) {
@@ -134,17 +167,17 @@ public class WidgetSetupActivity extends AppCompatActivity {
         this.isInRow = isInRow;
     }
 
-    public void showSizeDialog(WidgetLayout widget, Context ctx) {
-        boolean isWidget = widget != null;
+    private void showSizeDialog(boolean isWidget, int widgetId, boolean needsConfig) {
+        boolean creatingRow = !isWidget && widgetId == -1;
 
-        EditText input = new EditText(ctx);
+        EditText input = new EditText(this);
         input.setInputType(InputType.TYPE_CLASS_NUMBER);
 
         int maxNumber = isWidget ? 100 : 300;
 
         LinearLayout titleLayout = getTitleLayout(isWidget, maxNumber);
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(ctx);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle("enter size (0-" + maxNumber + ")");
         builder.setView(input);
         builder.setCustomTitle(titleLayout);
@@ -159,22 +192,65 @@ public class WidgetSetupActivity extends AppCompatActivity {
                     return;
                 }
                 double size = number / 100d;
-                if (isWidget) {
-                    widget.setSize(size);
-                } else {
+
+                if (creatingRow) {
                     WidgetList list = new WidgetList(size);
                     WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
                     widgetList.addChild(list);
+                    fs.storeFilesStructure();
+                    showLayout();
+                } else if (needsConfig) {
+                    launchConfigForWidget(widgetId, size, isWidget);
+                } else {
+                    addWidgetDirectly(widgetId, size, isWidget);
                 }
-                fs.storeFilesStructure();
-                showLayout();
             } catch (NumberFormatException e) {
                 Toast.makeText(this, "invalid number", Toast.LENGTH_LONG).show();
             }
         });
 
-        builder.setNegativeButton("Cancel", null);
+        builder.setNegativeButton("Cancel", (dialog, which) -> {
+            if (needsConfig && widgetId != -1) {
+                AppWidgetHost host = new AppWidgetHost(this, MainActivity.APPWIDGET_HOST_ID);
+                host.deleteAppWidgetId(widgetId);
+                pendingElement = null;
+            }
+        });
         builder.show();
+    }
+
+    private void addWidgetDirectly(int appWidgetId, double size, boolean inRow) {
+        WidgetElement element = new WidgetElement(appWidgetId, (int) (size * 100));
+
+        FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
+        WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
+
+        if (inRow) {
+            WidgetLayout lastElement = widgetList.getChildren().get(widgetList.getChildren().size() - 1);
+            ((WidgetList) lastElement).addChild(element);
+        } else {
+            widgetList.addChild(element);
+        }
+
+        fs.storeFilesStructure();
+        showLayout();
+    }
+
+    private void launchConfigForWidget(int appWidgetId, double size, boolean inRow) {
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
+        android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
+
+        if (widgetInfo != null && widgetInfo.configure != null) {
+            pendingElement = new WidgetElement(appWidgetId, (int) (size * 100));
+            this.isInRow = inRow;
+
+            ComponentName configureComponent = widgetInfo.configure;
+            Intent configureIntent = new Intent().setComponent(configureComponent);
+            configureIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+            configureIntent.putExtra("folder", folder);
+            configureIntent.setData(Uri.parse("widget:" + appWidgetId));
+            configureIntentLauncher.launch(configureIntent);
+        }
     }
 
     @NonNull

--- a/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/WidgetSetupActivity.java
@@ -450,15 +450,15 @@ public class WidgetSetupActivity extends AppCompatActivity {
                 double size = number / 100d;
 
                 if (creatingRow) {
-                    WidgetList list = new WidgetList(number);
+                    WidgetList list = new WidgetList(size);
                     WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
                     widgetList.addChild(list);
                     fs.storeFilesStructure();
                     showLayout();
                 } else if (needsConfig) {
-                    launchConfigForWidget(widgetId, (int) number, isWidget);
+                    launchConfigForWidget(widgetId, size, isWidget);
                 } else {
-                    addWidgetDirectly(widgetId, (int) number, isWidget);
+                    addWidgetDirectly(widgetId, size, isWidget);
                 }
             } catch (NumberFormatException e) {
                 Toast.makeText(this, "invalid number", Toast.LENGTH_LONG).show();
@@ -475,8 +475,8 @@ public class WidgetSetupActivity extends AppCompatActivity {
         builder.show();
     }
 
-    private void addWidgetDirectly(int appWidgetId, int sizePercent, boolean inRow) {
-        WidgetElement element = new WidgetElement(appWidgetId, sizePercent);
+    private void addWidgetDirectly(int appWidgetId, double size, boolean inRow) {
+        WidgetElement element = new WidgetElement(appWidgetId, size);
 
         FileDataStorage fs = FileDataStorage.getInstanceAssumeExists();
         WidgetList widgetList = fs.getFolderContents(folder).getWidgetList();
@@ -492,12 +492,12 @@ public class WidgetSetupActivity extends AppCompatActivity {
         showLayout();
     }
 
-    private void launchConfigForWidget(int appWidgetId, int sizePercent, boolean inRow) {
+    private void launchConfigForWidget(int appWidgetId, double size, boolean inRow) {
         AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(this);
         android.appwidget.AppWidgetProviderInfo widgetInfo = appWidgetManager.getAppWidgetInfo(appWidgetId);
 
         if (widgetInfo != null && widgetInfo.configure != null) {
-            pendingElement = new WidgetElement(appWidgetId, sizePercent);
+            pendingElement = new WidgetElement(appWidgetId, size);
             this.isInRow = inRow;
 
             ComponentName configureComponent = widgetInfo.configure;

--- a/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetElement.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetElement.java
@@ -4,7 +4,7 @@ public class WidgetElement extends WidgetLayout {
 
     int appWidgetId;
 
-    public WidgetElement(int appWidgetId, int size){
+    public WidgetElement(int appWidgetId, double size){
         super();
         this.appWidgetId = appWidgetId;
         this.size = size;

--- a/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
@@ -1,11 +1,15 @@
 package me.robbyblue.mylauncher.widgets;
 
+import android.appwidget.AppWidgetHost;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProviderInfo;
+import android.appwidget.AppWidgetHostView;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
-import android.view.Gravity;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
 import java.util.HashMap;
@@ -13,16 +17,24 @@ import java.util.HashMap;
 public class WidgetSystem {
 
     static boolean showOutlines;
+    static AppWidgetHost appWidgetHost;
 
-    public static HashMap<WidgetLayout, LinearLayout> createLayout(WidgetList widgets, LinearLayout container, boolean hasOutlines) {
+    public static HashMap<WidgetLayout, FrameLayout> createLayout(WidgetList widgets, LinearLayout container, boolean hasOutlines) {
+        return createLayout(widgets, container, hasOutlines, null);
+    }
+
+    public static HashMap<WidgetLayout, FrameLayout> createLayout(WidgetList widgets, LinearLayout container, boolean hasOutlines, AppWidgetHost host) {
         showOutlines = hasOutlines;
+        appWidgetHost = host;
 
         container.removeAllViewsInLayout();
-        HashMap<WidgetLayout, LinearLayout> layouts = new HashMap<>();
+        container.setClickable(true);
+        container.setFocusable(true);
+        HashMap<WidgetLayout, FrameLayout> layouts = new HashMap<>();
 
         for (WidgetLayout widget : widgets.getChildren()) {
             if (widget instanceof WidgetElement) {
-                LinearLayout layout = addTopLevelWidget((WidgetElement) widget, container);
+                FrameLayout layout = addTopLevelWidget((WidgetElement) widget, container);
                 layouts.put(widget, layout);
             }
             if (widget instanceof WidgetList) {
@@ -33,77 +45,154 @@ public class WidgetSystem {
         return layouts;
     }
 
-    private static LinearLayout addTopLevelWidget(WidgetElement widget, LinearLayout container) {
+    private static FrameLayout addTopLevelWidget(WidgetElement widget, LinearLayout container) {
         Context ctx = container.getContext();
-        LinearLayout childLayout = new LinearLayout(ctx);
+        FrameLayout wrapper = new FrameLayout(ctx);
 
-        int screenWidth = container.getWidth();
+        DisplayMetrics metrics = ctx.getResources().getDisplayMetrics();
+        int screenWidth = metrics.widthPixels;
+
+        double sizeValue = widget.getSize();
+        double sizePercent = sizeValue / 100.0;
+        if (sizePercent < 0.05) sizePercent = 0.05;
+        if (sizePercent > 1.0) sizePercent = 1.0;
+
+        int height = (int) (screenWidth * sizePercent);
+        if (height < 50) height = 50;
+
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(screenWidth, height);
+        wrapper.setLayoutParams(layoutParams);
+        wrapper.setPadding(8, 8, 8, 8);
+
+        if (!showOutlines && appWidgetHost != null) {
+            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(ctx);
+            AppWidgetProviderInfo appWidgetInfo = appWidgetManager.getAppWidgetInfo(widget.getAppWidgetId());
+            if (appWidgetInfo != null) {
+                AppWidgetHostView hostView = appWidgetHost.createView(ctx, widget.getAppWidgetId(), appWidgetInfo);
+                hostView.setAppWidget(widget.getAppWidgetId(), appWidgetInfo);
+                wrapper.addView(hostView);
+            }
+        }
 
         if (showOutlines) {
-            childLayout.setBackground(createOutline(Color.MAGENTA));
+            wrapper.setBackground(createOutline(Color.MAGENTA));
+            View overlay = new View(ctx);
+            overlay.setBackgroundColor(0x4000FF00);
+            wrapper.addView(overlay);
         }
 
-        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(ctx);
-        AppWidgetProviderInfo appWidgetInfo = appWidgetManager.getAppWidgetInfo(((WidgetElement) widget).getAppWidgetId());
+        wrapper.setClickable(true);
+        wrapper.setFocusable(true);
+        wrapper.setFocusableInTouchMode(true);
 
-        if (appWidgetInfo == null) {
-            LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(screenWidth, 100);
-            childLayout.setLayoutParams(layoutParams);
-            container.addView(childLayout);
-            return childLayout;
-        }
+        wrapper.setOnTouchListener((v, event) -> {
+            if (event.getActionMasked() == android.view.MotionEvent.ACTION_UP) {
+                v.performClick();
+            }
+            return false;
+        });
 
-        int minWidth = appWidgetInfo.minWidth;
-        int minHeight = appWidgetInfo.minHeight;
-
-        if (minWidth == 0) {
-            minWidth = minHeight = 1;
-        }
-
-        int height = (int) (screenWidth * minHeight / minWidth);
-        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(screenWidth, height);
-        childLayout.setLayoutParams(layoutParams);
-        childLayout.setGravity(Gravity.CENTER);
-
-        container.addView(childLayout);
-        return childLayout;
+        container.addView(wrapper);
+        return wrapper;
     }
 
-    private static void addRow(WidgetList widget, LinearLayout container, HashMap<WidgetLayout, LinearLayout> layouts) {
+    private static void addRow(WidgetList widget, LinearLayout container, HashMap<WidgetLayout, FrameLayout> layouts) {
         Context ctx = container.getContext();
-        LinearLayout childLayout = new LinearLayout(ctx);
+        FrameLayout wrapper = new FrameLayout(ctx);
 
-        int screenWidth = container.getWidth();
-        int height = (int) (screenWidth * widget.getSize());
+        DisplayMetrics metrics = ctx.getResources().getDisplayMetrics();
+        int screenWidth = metrics.widthPixels;
+
+        double sizeValue = widget.getSize();
+        double sizePercent = sizeValue / 100.0;
+        if (sizePercent < 0.05) sizePercent = 0.05;
+        if (sizePercent > 1.0) sizePercent = 1.0;
+
+        int height = (int) (screenWidth * sizePercent);
+        if (height < 50) height = 50;
+
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(screenWidth, height);
-        childLayout.setLayoutParams(layoutParams);
+        wrapper.setLayoutParams(layoutParams);
 
         if (showOutlines) {
-            childLayout.setBackground(createOutline(Color.BLUE));
+            wrapper.setBackground(createOutline(Color.BLUE));
+            View overlay = new View(ctx);
+            overlay.setBackgroundColor(0x400000FF);
+            wrapper.addView(overlay);
         }
+
+        wrapper.setClickable(true);
+        wrapper.setFocusable(true);
+        wrapper.setFocusableInTouchMode(true);
+
+        wrapper.setOnTouchListener((v, event) -> {
+            if (event.getActionMasked() == android.view.MotionEvent.ACTION_UP) {
+                v.performClick();
+            }
+            return false;
+        });
+
+        LinearLayout rowContent = new LinearLayout(ctx);
+        rowContent.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+        rowContent.setOrientation(LinearLayout.HORIZONTAL);
 
         for (WidgetLayout child : widget.getChildren()) {
-            addWidgetInRow(child, childLayout, layouts, screenWidth, height);
+            addWidgetInRow(child, rowContent, layouts, screenWidth, height);
         }
 
-        container.addView(childLayout);
+        wrapper.addView(rowContent);
+
+        container.addView(wrapper);
+        layouts.put(widget, wrapper);
     }
 
-    private static void addWidgetInRow(WidgetLayout widget, LinearLayout container, HashMap<WidgetLayout, LinearLayout> layouts, int parentWidth, int parentHeight) {
+    private static void addWidgetInRow(WidgetLayout widget, LinearLayout container, HashMap<WidgetLayout, FrameLayout> layouts, int parentWidth, int parentHeight) {
         Context ctx = container.getContext();
-        LinearLayout childLayout = new LinearLayout(ctx);
+        FrameLayout wrapper = new FrameLayout(ctx);
 
-        int width = (int) (parentWidth * widget.getSize());
+        double sizeValue = widget.getSize();
+        double sizePercent = sizeValue / 100.0;
+        if (sizePercent < 0.01) sizePercent = 0.01;
+        if (sizePercent > 1.0) sizePercent = 1.0;
+
+        int width = (int) (parentWidth * sizePercent);
+        if (width < 20) width = 20;
 
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(width, parentHeight);
-        childLayout.setLayoutParams(layoutParams);
+        wrapper.setLayoutParams(layoutParams);
 
-        if (showOutlines) {
-            childLayout.setBackground(createOutline(Color.GREEN));
+        if (!showOutlines && widget instanceof WidgetElement && appWidgetHost != null) {
+            WidgetElement element = (WidgetElement) widget;
+            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(ctx);
+            AppWidgetProviderInfo appWidgetInfo = appWidgetManager.getAppWidgetInfo(element.getAppWidgetId());
+
+            if (appWidgetInfo != null) {
+                AppWidgetHostView hostView = appWidgetHost.createView(ctx, element.getAppWidgetId(), appWidgetInfo);
+                hostView.setAppWidget(element.getAppWidgetId(), appWidgetInfo);
+                wrapper.addView(hostView);
+            }
         }
 
-        container.addView(childLayout);
-        layouts.put(widget, childLayout);
+        if (showOutlines) {
+            wrapper.setBackground(createOutline(Color.GREEN));
+            View overlay = new View(ctx);
+            overlay.setBackgroundColor(0x4000FF00);
+            wrapper.addView(overlay);
+        }
+
+        wrapper.setClickable(true);
+        wrapper.setFocusable(true);
+        wrapper.setFocusableInTouchMode(true);
+
+        wrapper.setOnTouchListener((v, event) -> {
+            if (event.getActionMasked() == android.view.MotionEvent.ACTION_UP) {
+                v.performClick();
+            }
+            return false;
+        });
+
+        container.addView(wrapper);
+        layouts.put(widget, wrapper);
     }
 
     private static GradientDrawable createOutline(int color) {

--- a/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
+++ b/app/src/main/java/me/robbyblue/mylauncher/widgets/WidgetSystem.java
@@ -53,9 +53,7 @@ public class WidgetSystem {
         int screenWidth = metrics.widthPixels;
 
         double sizeValue = widget.getSize();
-        double sizePercent = sizeValue / 100.0;
-        if (sizePercent < 0.05) sizePercent = 0.05;
-        if (sizePercent > 1.0) sizePercent = 1.0;
+        double sizePercent = Math.max(0.05, (Math.min(sizeValue, 1.0)));
 
         int height = (int) (screenWidth * sizePercent);
         if (height < 50) height = 50;
@@ -104,9 +102,7 @@ public class WidgetSystem {
         int screenWidth = metrics.widthPixels;
 
         double sizeValue = widget.getSize();
-        double sizePercent = sizeValue / 100.0;
-        if (sizePercent < 0.05) sizePercent = 0.05;
-        if (sizePercent > 1.0) sizePercent = 1.0;
+        double sizePercent = Math.max(0.05, (Math.min(sizeValue, 1.0)));
 
         int height = (int) (screenWidth * sizePercent);
         if (height < 50) height = 50;
@@ -151,9 +147,7 @@ public class WidgetSystem {
         FrameLayout wrapper = new FrameLayout(ctx);
 
         double sizeValue = widget.getSize();
-        double sizePercent = sizeValue / 100.0;
-        if (sizePercent < 0.01) sizePercent = 0.01;
-        if (sizePercent > 1.0) sizePercent = 1.0;
+        double sizePercent = Math.max(0.05, (Math.min(sizeValue, 1.0)));
 
         int width = (int) (parentWidth * sizePercent);
         if (width < 20) width = 20;


### PR DESCRIPTION
Currently, widgets need to be added linearly, row by row.

This PR adds the ability to move and reconfigure widgets after they've been added to the launcher, without needing to delete and re-add them.
Before, long-press on a widget removed it. Removing an empty row was only possible by leaving the edit mode and coming back to it. Now, they are permanent and need manual deletion. Both short-press and long-press on widgets and rows now open an options menu. Users can
- delete widgets,
- reconfigure them if they have a config activity, allowing later configuration and updating widgets, and
- reorder them. (Moving works as swap with neighbour)
 
For top-level widgets and rows, users can move them up or down. For widgets inside rows, users can move them left or right. I took the freedom show widgets with a green overlay and rows with a blue overlay.

During coding I tried to show the widgets during edit mode, but was not able to disable their interactivity.

This PR depends on
- [ ] #100 

If you think this PR is an improvement and would add it in a future release, the instructions in the README.md would need to be updated.

ea3e031 adds input validation for widget and row size dialogs. It validates size input before allowing dialog to close and shows an error toast when input is outside valid range (1-100 for widgets, 1-300 for rows). This keeps the dialog open until valid input is entered.